### PR TITLE
Fix failing GitHub Actions

### DIFF
--- a/.github/workflows/dailyaws.yml
+++ b/.github/workflows/dailyaws.yml
@@ -16,7 +16,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10.2' # install the python version needed
+          python-version: '3.11' # install the python version needed
 
       - name: execute py script
         run: python getips.py

--- a/.github/workflows/dailyaws.yml
+++ b/.github/workflows/dailyaws.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
       - name: checkout repo content
-        uses: actions/checkout@v2 # checkout the repository content to github runner
+        uses: actions/checkout@v3 # checkout the repository content to github runner
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10.2' # install the python version needed
 

--- a/getips.py
+++ b/getips.py
@@ -1,12 +1,13 @@
-#!/usr/bin/env python
-
 # Standard Python Libraries
 import ipaddress
 import json
+from typing import Iterator, Union
 import urllib.request
 
 
-def output_cidrs(filename: str, cidrs: list[str]):
+def output_cidrs(
+    filename: str, cidrs: Iterator[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]
+):
     """Output the given CIDRs to the given file."""
     with open(filename, "w", encoding="utf-8") as out:
         for cidr in cidrs:


### PR DESCRIPTION
This pull request's primary focus is fixing the currently failing GitHub Actions workflow. It is currently failing because the version of Python specified (`3.10.2`) is not available to `ubuntu-22.04` runners (the tag that the `ubuntu-latest` tag is migrating to from `ubuntu-20.04`). That is resolves by updating the version pin to `3.11`. This gets the workflow on the latest version of Python and omits the patch version so that the workflow will get the latest `3.11.x` release available when run. This will allow any performance/security/other updates that are available in patch releases to automatically be available as long as a build is available to the runner.

The versions of the [actions/checkout](https://github.com/actions/checkout) and [actions/setup-python](https://github.com/actions/setup-python) GitHub actions were also updated to their latest major version. In addition to getting them up-to-date this also resolves warning due to the upcoming retirement of Node.js 12 actions since the latest major versions are using Node.js 16.

While I was here I also did a minor fixup on the `getips.py` script to remove an unnecessary shebang and fix the typing of the `output_cidrs()` function.

I verified that the updates ran successfully in [this branch](https://github.com/mcdonnnj/awsips/tree/testing).